### PR TITLE
New command line argument parser, seed support and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ This version introduces several changes:
 - Updated documentation
 - Added a toggle to ignore genotype errors
 - Improved project structure
+- New command-line argument parsing
+
+## Quick Start
+Skip this section if you want a detailed guide on how to install & run BORICE.
+```properties
+# Clone BORICE
+git clone https://github.com/Ferne-Kotlyar/BORICE
+
+# Change directory
+cd BORICE
+
+# Install BORICE
+pip install -r requirements.txt
+pip install -e .
+
+# Run BORICE CLI with the default settings
+python borice example_datafile.csv
+
+# Run BORICE GUI
+python borice_gui
+```
 
 ## Requirements
 BORICE was initially developed using Python 2.7. It has been updated to work with Python 3 (tested with 3.9.12), but should work with other versions of Python 3 as well.
@@ -23,90 +44,139 @@ The installation guide bellow assumes that you are familiar with:
 - [CLI](https://en.wikipedia.org/wiki/Command-line_interface) (command-line interface, such as *terminal* on MacOS/Linux, and *Command Prompt* on Windows)
 
 ## Installation
-Install the requirements by typing:
-```
+Install BORICE requirements by typing this command:
+```properties
 pip install -r requirements.txt
 ```
 
-You can then install the local package by typing:
-```
+You can then install the package by typing:
+```properties
 pip install -e .
 ```
 
-## Running
-After the installation is complete, you can run BORICE using one of these commands:
-- GUI (Graphical User Interface version):
+## Usage
+### BORICE CLI (for command-line users)
+BORICE CLI is recommended for users who are familiar with command-line programs. BORICE CLI comes in handy when BORICE needs to be executed from another program (ex: running BORICE from an R script).
+
+To run BORICE with the default settings, type the following command:
+```properties
+python borice example_datafile.csv
 ```
+Replace `example_datafile.csv` with any CSV data file you want to work with (see data file formatting below).
+
+BORICE CLI comes with a variety of settings. You can read about these options by typing:
+```properties
+python borice --help
+```
+
+### BORICE GUI (recommended)
+As opposed to the CLI version, the GUI version of BORICE doesn't take any command-line arguments, instead, BORICE GUI lets you tweak its settings through a graphical user interface (GUI). To run BORICE GUI, you can type this command:
+```properties
 python borice_gui
 ```
+Once BORICE GUI is open, you should see a blank screen. In the menu bar, click on "File", then "Open Data File"; select your input data file. A setting panel should appear where you can choose to edit BORICE's default parameters.
 
-- CLI (Command-line version):
+Click "Run" to start processing your data. You will get an alert message when the run is complete.
+
+Settings for BORICE are separated into several tabs:
+
+#### General Settings
+|Setting|Default|Description|
+|-|-|-|
+|Number of Steps|`100000`|Number of steps taken in the MCMC chain. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the chain length is too short.|
+|Number of Burn In Steps|`9999`|Number of initial steps that will be discarded before the posterior distributions are calculated. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the burn-in length is too short.|
+|Outcrossing Rate Tuning Parameter|`0.05`|Determines how large a change in outcrossing rate is made at each step.|
+|Allele Frequency Tuning Parameter|`0.1`|Determines how large a change in allele frequency is made at each step.|
+|Initial Population Outcrossing Rate|`0.5`|Determines the starting outcrossing rate value for the chain.|
+|Ignore Genotyping Errors|`False`|Skips any offspring that has an allele that does not match the mother if set to `True`.|
+
+#### File Output Options
+You also have the option of choosing the output files from your BORICE run under the “File Output Options” tab. The default settings are to produce all files. Output 1 is always produced; it contains the posterior distributions of t and F, population inbreeding history, and allele frequencies at each locus. Output 2 contains the posterior distributions of maternal inbreeding histories. Output 3 contains the list of t and F values from every 10 steps in the MCMC chain. Output 4 contains the posterior distributions for each maternal genotype at each locus in each family. These output files are tab-delimited text files that can be imported into spreadsheets.
+Setting|Default|
+|-|-|
+|Posterior Distributions of Maternal Inbreeding Histories|`True`|
+|List of t and F values|`True`|
+|Posterior Distributions for each maternal genotype at each locus in each family|`True`|
+
+#### Input Data Summary
+The "Input Data Summary" tab shows you the number of marker loci, number of families, and number of individuals read from your input data file. If these numbers are not correct, then you should check your input data file.
+
+#### Locus Settings
+The "Locus Settings" tab allows you to choose whether to run each locus as having null alleles or not. The default setting is all boxes unchecked, which means null alleles will not be considered at a locus. Checking a locus box means null alleles will be considered at that locus. If you are uncertain whether or not to run BORICE with null alleles considered at a locus, you may want to try running BORICE with and without null alleles to compare the average ln likelihood. If you see a substantial improvement in the ln likelihood when running the model with null alleles at that locus, then null alleles may be present. In addition, BORICE makes an initial check of the data for impossible genotypes. If impossible genotypes are present at a locus even after you have checked your data for input errors, then null alleles may be present at that locus and you may wish to try the model with null alleles considered.
+|Setting|Default|Description|
+|-|-|-|
+|Locus *n*|`True`|Considers null alleles at locus `n` if set to `True`|
+
+## Data file format (CSV)
+BORICE takes genotype data in the form of comma-separated value (CSV) files. In your csv file, missing data should be coded as `-9`.
+
+### First Row
+This row should contain the following in the first three cells:
+1. the number of marker loci,
+2. `0` or `1` to indicate the absence or presence of a population name in your data
+3. `0` or `1` to indicate the absence or presence of a subgroup name in your data.
+   
+Currently, subgroups are not supported, so if subgroups are present they will be ignored.
+
+*Example:*
 ```
-python borice
-	[data file name]
-	[locus 1]
-	[locus 2]
-	[locus 3]
-	[number of steps]
-	[number of burn in steps]
-	[outcrossing rate tuning parameter]
-	[allele frequency tuning parameter]
-	[outcrossing rate tuning parameter]
-	[write output 2]
-	[write output 3]
-	[write output 4]
-	[ignore genotyping errors]
+3,1,0
 ```
 
-## Unit Tests
-To run the unit tests (using the `example_datafile.csv`), you can run this command:
+### Second Row
+The second row should contain the names of your marker loci.
+
+*Example:*
 ```
-py.test
+aat374,aat240,aat367
 ```
 
-## How To Format Your Data Files for Use with BORICE
-BORICE takes genotype data in the form of comma-separated value (csv) files. In your csv file, missing data should be coded as '-9'. The first row of the csv file should contain the following in the first three cells: 1) the number of marker loci, 2) a 0 or 1 to indicate the absence or presence of a population name in your data, and 3) a 0 or 1 to indicate the absence or presence of a subgroup name in your data. Currently, subgroups are not supported, so if subgroups are present they will be ignored. The second row should contain the names of your marker loci. All other rows should be in the following format: cell 1 = family name; cell 2 = population name (unless there isn't one); cell 3 = allele 1 of marker locus 1; cell 4 = allele 2 of marker locus 1; and so forth for all loci. If maternal individuals are present, they should be indicated with a '!' after the family name (e.g., 'fam1!').
+### Following Rows
+All other rows should be in the following format:
+1. family name
+2. population name (unless there isn't one)
+3. allele 1 of marker locus 1
+4. allele 2 of marker locus 1
+5. [...] *and so forth for all loci.*
+
+*Example:*
+```
+10,SS,152,152,98,98,-9,-9
+```
+
+If maternal individuals are present, they should be indicated with a `!` after the family name (*e.g., `fam1!`*).
 
 ### Example Data File
-```
+```csv
 3,1,0,,,,,
 aat374,aat240,aat367,,,,,
-10,SS,152,152,98,98,-9,-9
+10!,SS,152,152,98,98,-9,-9
 10,SS,149,149,98,98,185,191
 10,SS,149,149,98,98,191,191
 10,SS,149,149,98,98,185,191
-100,SS,149,152,98,98,185,185
+100!,SS,149,152,98,98,185,185
 100,SS,149,149,98,98,185,185
 100,SS,149,152,98,98,185,185
 100,SS,149,152,98,98,188,188
-12,SS,149,149,98,98,185,191
+12!,SS,149,149,98,98,185,191
 12,SS,149,152,98,98,185,191
 12,SS,149,152,98,98,185,191
 12,SS,152,152,-9,-9,-9,-9
-14,SS,149,149,98,98,185,185
+14!,SS,149,149,98,98,185,185
 ```
 
-## Usage
-Once BORICE GUI is open, click on the file menu and select “Open Data File”. Then select your input data file. You will then have the option to run BORICE with default settings or to change the settings. Below are the default settings listed under the “General Settings” tab.
+## Output Files
+BORICE generates 4 output files. The first one (Output 1) is always generated, the rest are optional.
 
-### Default Settings
-|Setting|Default Value|Description|
-|-|-|-|
-|Number of Steps|100000|The number of steps is the number of steps taken in the MCMC chain. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the chain length is too short.|
-|Number of Burn In Steps|9999|The number of burn in steps is the number of initial steps that will be discarded before the posterior distributions are calculated. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the burn-in length is too short.|
-|Outcrossing Rate Tuning Parameter|0.5|The outcrossing rate tuning parameter is the value that determines how large a change in outcrossing rate is made at each step.|
-|Allele Frequency Tuning Parameter|0.1|The allele frequency tuning parameter is the value that determines how large a change in allele frequency is made at each step.|
-|Initial Population Outcrossing Rate|0.5|The initial population outcrossing rate is the starting outcrossing rate value for the chain.|
-|Ignore Genotyping Errors|False|If true, BORICE skips any offspring that has an allele that does not match the mother.|
+|Generated File|Description|
+|-|-|
+|Output 1|Posterior Distribution of Population Inbreeding History|
+|Output 2|Posterior Distributions of Maternal Inbreeding Histories|
+|Output 3|List of t and F values|
+|Output 4|Posterior Distributions for each maternal genotype at each locus in each family|
 
-### File Output Options
-You also have the option of choosing the output files from your BORICE run under the “File Output Options” tab. The default settings are to produce all files. Output 1 is always produced; it contains the posterior distributions of t and F, population inbreeding history, and allele frequencies at each locus. Output 2 contains the posterior distributions of maternal inbreeding histories. Output 3 contains the list of t and F values from every 10 steps in the MCMC chain. Output 4 contains the posterior distributions for each maternal genotype at each locus in each family. These output files are tab-delimited text files that can be imported into spreadsheets.
-
-### Input Data Check
-The “Input Data Summary” tab shows you the number of marker loci, number of families, and number of individuals read from your input data file. If these numbers are not correct, then you should check your input data file.
-
-### Locus Settings
-The “Locus Settings” tab allows you to choose whether to run each locus as having null alleles or not. The default setting is all boxes unchecked, which means null alleles will not be considered at a locus. Checking a locus box means null alleles will be considered at that locus. If you are uncertain whether or not to run BORICE with null alleles considered at a locus, you may want to try running BORICE with and without null alleles to compare the average ln likelihood. If you see a substantial improvement in the ln likelihood when running the model with null alleles at that locus, then null alleles may be present. In addition, BORICE makes an initial check of the data for impossible genotypes. If impossible genotypes are present at a locus even after you have checked your data for input errors, then null alleles may be present at that locus and you may wish to try the model with null alleles considered.
-
-### Running the Program
-Click “Run” to run BORICE. If you do not see the prompt in the Command or Terminal window, BORICE is running. You will get an alert message when the run is complete.
+## Unit Tests
+BORICE has been setup to use [PyTest](https://pytest.org). You can run BORICE unit tests with the following command:
+```properties
+pytest
+```

--- a/borice/__main__.py
+++ b/borice/__main__.py
@@ -1,36 +1,92 @@
-import sys
+import argparse
 
 from borice.application import *
 
 def main():
+	parser = argparse.ArgumentParser()
+
+	parser.add_argument(dest='datafile',
+						help='input data file (formatted as CSV)')
+
+	parser.add_argument('--locus',
+						type=bool,
+						default=Application.LOCUS_MODEL,
+						nargs='*',
+						dest='locus_model',
+						help='considers null alleles at a given locus if set to True (ex: 0 1 0)')
+
+	parser.add_argument('--steps',
+						type=int,
+						default=Application.NUM_STEPS,
+						dest='steps',
+						help='number of steps taken in the MCMC chain. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the chain length is too short.')
+
+	parser.add_argument('--burnin-steps',
+						type=int,
+						default=Application.BURN_IN,
+						dest='burnin_steps',
+						help='number of initial steps that will be discarded before the posterior distributions are calculated. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the burn-in length is too short.')
+
+	parser.add_argument('--outcrossing-tuning',
+						type=float,
+						default=Application.OUTCROSSING_RATE_TUNING,
+						dest='outcrossing_tuning',
+						help='determines how large a change in outcrossing rate is made at each step.')
+
+	parser.add_argument('--allele-frequency-tuning',
+						type=float,
+						default=Application.ALLELE_FREQUENCY_TUNING,
+						dest='allele_frequency_tuning',
+						help='determines how large a change in allele frequency is made at each step.')
+
+	parser.add_argument('--outcrossing-rate',
+						type=float,
+						default=Application.INITIAL_OUTCROSSING_RATE,
+						dest='outcrossing_rate',
+						help='determines the starting outcrossing rate value for the chain.')
+
+	parser.add_argument('--ignore-genotyping-errors',
+						action='store_true',
+						dest='ignore_genotyping_errors',
+						help='skips any offspring that has an allele that does not match the mother if set to True.')
+
+	parser.add_argument('--skip-output-2',
+						action='store_false',
+						dest='write_output_2',
+						help='skips writing the output file 2 (posterior distributions of maternal inbreeding histories).')
+
+	parser.add_argument('--skip-output-3',
+						action='store_false',
+						dest='write_output_3',
+						help='skips writing the output file 3 (list of t and F values from every 10 steps in the MCMC chain).')
+
+	parser.add_argument('--skip-output-4',
+						action='store_false',
+						dest='write_output_4',
+						help='skips writing the output file 4 (posterior distributions for each maternal genotype at each locus in each family).')
+
+	parser.add_argument('--seed',
+						type=int,
+						default=Application.SEED,
+						dest='seed',
+						help='custom seed used for random number generation')
+
+	args = parser.parse_args()
+
 	app = Application()
-	dataFileName = sys.argv[1]
-	#locus_model = [bool(int(sys.argv[2])), bool(int(sys.argv[3])), bool(int(sys.argv[4])), bool(int(sys.argv[5])), bool(int(sys.argv[6])), bool(int(sys.argv[7])), bool(int(sys.argv[8])), bool(int(sys.argv[9])), bool(int(sys.argv[10])), bool(int(sys.argv[11]))]
-	locus_model = [bool(int(sys.argv[2])), bool(int(sys.argv[3])), bool(int(sys.argv[4]))]
-	numSteps = int(sys.argv[5])
-	numBurnInSteps = int(sys.argv[6])
-	outcrossingRateTuningParam = float(sys.argv[7])
-	alleleFreqTuningParam = float(sys.argv[8])
-	outcrossingRate = float(sys.argv[9])
-	writeOutput2, writeOutput3, writeOutput4 = True, True, True
-	try:
-		writeOutput2 = bool(int(sys.argv[10]))
-		writeOutput3 = bool(int(sys.argv[11]))
-		writeOutput4 = bool(int(sys.argv[12]))
-	except:
-		pass
-	sys.stderr.write(repr(dataFileName) + '\n	 ')
-	sys.stderr.write(repr(locus_model) + '\n	 ')
-	sys.stderr.write(repr(numSteps) + '\n	 ')
-	sys.stderr.write(repr(numBurnInSteps) + '\n   ')
-	sys.stderr.write(repr(outcrossingRateTuningParam) + '\n   ')
-	sys.stderr.write(repr(alleleFreqTuningParam) + '\n	  ')
-	sys.stderr.write(repr(outcrossingRate) + '\n	')
-	sys.stderr.write(repr(writeOutput2) + '\n	 ')
-	sys.stderr.write(repr(writeOutput3) + '\n	 ')
-	sys.stderr.write(repr(writeOutput4) + '\n	 ')
-		
-	app.run(dataFileName, locus_model, numSteps, numBurnInSteps, outcrossingRateTuningParam, alleleFreqTuningParam, outcrossingRate, writeOutput2, writeOutput3, writeOutput4)
+
+	app.run(args.datafile,
+			args.locus_model,
+			args.steps,
+			args.burnin_steps,
+			args.outcrossing_tuning,
+			args.allele_frequency_tuning,
+			args.outcrossing_rate,
+			args.write_output_2,
+			args.write_output_3,
+			args.write_output_4,
+			args.ignore_genotyping_errors,
+			args.seed)
 
 if __name__ == '__main__':
 	main()

--- a/borice_gui/main_window.py
+++ b/borice_gui/main_window.py
@@ -29,11 +29,11 @@ class MainWindow(QMainWindow):
 		# Input/Output Data
 		#
 		#Outcrossing Rate. Can range from 0-1
-		self.outcrossingRate = 0.50
+		self.outcrossingRate = Application.INITIAL_OUTCROSSING_RATE
 		#Number of steps
-		self.numSteps = 100000
+		self.numSteps = Application.NUM_STEPS
 		#Number of steps to burn in
-		self.numBurnInSteps = 9999
+		self.numBurnInSteps = Application.BURN_IN
 		#Number of steps taken
 		self.numStepsTaken = None
 		#Number of marker loci
@@ -47,14 +47,14 @@ class MainWindow(QMainWindow):
 
 		self.dataFileName = ""
 
-		self.outcrossingRateTuningParam = 0.05
-		self.alleleFreqTuningParam = 0.1
+		self.outcrossingRateTuningParam = Application.OUTCROSSING_RATE_TUNING
+		self.alleleFreqTuningParam = Application.ALLELE_FREQUENCY_TUNING
 		
-		self.writeOutput2 = True
-		self.writeOutput3 = True
-		self.writeOutput4 = True
+		self.writeOutput2 = Application.WRITE_OUTPUT_2
+		self.writeOutput3 = Application.WRITE_OUTPUT_3
+		self.writeOutput4 = Application.WRITE_OUTPUT_4
 
-		self.ignoreGenotypingErrors = False
+		self.ignoreGenotypingErrors = Application.IGNORE_GENOTYPING_ERRORS
 
 		#build the user interface
 		self.setupUI()
@@ -104,31 +104,31 @@ class MainWindow(QMainWindow):
 		#Max Widths
 		maxLineWidth = 250
 		
-		self.numStepsText = QLineEdit("100000")
+		self.numStepsText = QLineEdit(str(self.numSteps))
 		self.numStepsText.textChanged.connect(self.setNumSteps)
 		self.numStepsText.setMaximumWidth(maxLineWidth)
 		self.numStepsText.setAlignment(QtCore.Qt.AlignRight)
 		self.numStepsText.setValidator(posValidator)
 		#Number of steps to Burn In input
-		self.numStepsBurnInText = QLineEdit("9999")
+		self.numStepsBurnInText = QLineEdit(str(self.numBurnInSteps))
 		self.numStepsBurnInText.textChanged.connect(self.setBurnInSteps)
 		self.numStepsBurnInText.setMaximumWidth(maxLineWidth)
 		self.numStepsBurnInText.setAlignment(QtCore.Qt.AlignRight)
 		self.numStepsBurnInText.setValidator(posValidator)
 		#Outcrossing Rate Tuning Parameter
-		self.outcrossingRateTuningParamText = QLineEdit("0.05")
+		self.outcrossingRateTuningParamText = QLineEdit(str(self.outcrossingRateTuningParam))
 		self.outcrossingRateTuningParamText.textChanged.connect(self.setOutcrossingRateTuningParam)
 		self.outcrossingRateTuningParamText.setMaximumWidth(maxLineWidth)
 		self.outcrossingRateTuningParamText.setAlignment(QtCore.Qt.AlignRight)
 		self.outcrossingRateTuningParamText.setValidator(zeroOneValidator)
 		#Initial Population Outcrossing Rate
-		self.initialPopulationOutcrossingRateText = QLineEdit("0.5")
+		self.initialPopulationOutcrossingRateText = QLineEdit(str(self.outcrossingRate))
 		self.initialPopulationOutcrossingRateText.textChanged.connect(self.setInitialPopulationOutcrossingRate)
 		self.initialPopulationOutcrossingRateText.setValidator(zeroOneValidator)
 		self.initialPopulationOutcrossingRateText.setMaximumWidth(maxLineWidth)
 		self.initialPopulationOutcrossingRateText.setAlignment(QtCore.Qt.AlignRight)
 		#Allele Frequency Tuning Parameter
-		self.AlleleFreqTuningParamText = QLineEdit("0.1")
+		self.AlleleFreqTuningParamText = QLineEdit(str(self.alleleFreqTuningParam))
 		self.AlleleFreqTuningParamText.textChanged.connect(self.setAlleleFreqTuningParam)
 		self.AlleleFreqTuningParamText.setMaximumWidth(maxLineWidth)
 		self.AlleleFreqTuningParamText.setAlignment(QtCore.Qt.AlignRight)
@@ -149,17 +149,17 @@ class MainWindow(QMainWindow):
 		
 		#Posterior Distributions of Maternal Inbreeding Histories
 		self.outputOptionTwoCheckBox = QCheckBox()
-		self.outputOptionTwoCheckBox.setChecked(True)
+		self.outputOptionTwoCheckBox.setChecked(self.writeOutput2)
 		self.outputOptionTwoCheckBox.toggled.connect(self.setWrite2)
 		
 		#List of t and F values
 		self.outputOptionThreeCheckBox = QCheckBox()
-		self.outputOptionThreeCheckBox.setChecked(True)
+		self.outputOptionThreeCheckBox.setChecked(self.writeOutput3)
 		self.outputOptionThreeCheckBox.toggled.connect(self.setWrite3)
 		
 		#Posterior Distributions for each maternal genotype at each locus in each family
 		self.outputOptionFourCheckBox = QCheckBox()
-		self.outputOptionFourCheckBox.setChecked(True)
+		self.outputOptionFourCheckBox.setChecked(self.writeOutput4)
 		self.outputOptionFourCheckBox.toggled.connect(self.setWrite4)
 		
 		#Connect run button to spawn a progress dialog when clicked

--- a/tests/test_borice.py
+++ b/tests/test_borice.py
@@ -1,5 +1,6 @@
 from borice.application import *
 
-# Test borice with default parameters
+# Test borice
 def test_borice():
-    Application().run("example_datafile.csv", [True, True, True])
+    app = Application()
+    app.run("example_datafile.csv", num_steps=100, burn_in=1, seed=123)


### PR DESCRIPTION
### Command Line Update
The command line version of BORICE (CLI) has been updated to support optional parameters and to work with variable locus count.
```
usage: borice [-h] [--locus [LOCUS_MODEL ...]] [--steps STEPS] [--burnin-steps BURNIN_STEPS] [--outcrossing-tuning OUTCROSSING_TUNING] [--allele-frequency-tuning ALLELE_FREQUENCY_TUNING]
              [--outcrossing-rate OUTCROSSING_RATE] [--ignore-genotyping-errors] [--skip-output-2] [--skip-output-3] [--skip-output-4] [--seed SEED]
              datafile

positional arguments:
  datafile              datafile to use (Formatted as CSV)

options:
  -h, --help            show this help message and exit
  --locus [LOCUS_MODEL ...]
                        locus Model (Ex: 1 1 1)
  --steps STEPS         number of steps taken in the MCMC chain. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the chain length is too short.
  --burnin-steps BURNIN_STEPS
                        number of initial steps that will be discarded before the posterior distributions are calculated. If replicate runs of BORICE yield varying estimates of t or F, this may indicate that the burn-in   
                        length is too short.
  --outcrossing-tuning OUTCROSSING_TUNING
                        determines how large a change in outcrossing rate is made at each step.
  --allele-frequency-tuning ALLELE_FREQUENCY_TUNING
                        determines how large a change in allele frequency is made at each step.
  --outcrossing-rate OUTCROSSING_RATE
                        starting outcrossing rate value for the chain.
  --ignore-genotyping-errors
                        skips any offspring that has an allele that does not match the mother.
  --skip-output-2       skips writing the output file 2 (posterior distributions of maternal inbreeding histories).
  --skip-output-3       skips writing the output file 3 (list of t and F values from every 10 steps in the MCMC chain).
  --skip-output-4       skips writing the output file 4 (posterior distributions for each maternal genotype at each locus in each family).
  --seed SEED           custom seed for random number generations
```

### Adding support for seed (CLI-specific)
Previously, BORICE allowed users to set a custom seed through the operating system environment variables. To make it easier to run BORICE with a custom seed, it is now possible to set a seed with the command-line argument: `--seed SEED`.

### Updated README.md
The [`README.md`](https://github.com/Ferne-Kotlyar/BORICE#readme) has been updated to introduce a quick start guide (faster installation & usage for experienced users).

The installation and usage guides have been rewritten to make them easier to follow