### PR TITLE
Adding output validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyQt5==5.15.7
 pytest==7.1.2
+PyYAML==6.0
 setuptools==58.1.0

--- a/tests/test_borice.py
+++ b/tests/test_borice.py
@@ -1,6 +1,53 @@
+import yaml
+import hashlib
+import pytest
+
 from borice.application import *
 
+def hashfile(filename):
+	BLOCKSIZE = 65536
+	hasher = hashlib.sha1()
+	with open(filename, 'r') as f:
+		while True:
+			data = f.read(BLOCKSIZE)
+			if not data:
+				break
+			hasher.update(data.encode())
+	return hasher.hexdigest()
+
+def getOrDefault(dict, key, default):
+	if key in dict:
+		return dict[key]
+	else:
+		return default
+
+def evaluateTest(app, test):
+	# Pass the args to BORICE except the hash (result)
+	args = {key:test[key] for key in test if key != 'hash'}
+	app.run(**args)
+	hash = hashfile('BORICE_output1.txt')
+
+	# If the test has no saved hash, register it
+	if not 'hash' in test:
+		test['hash'] = hash
+		return 1
+
+	assert hash == test['hash']
+	return 0
+
 # Test borice
-def test_borice():
-    app = Application()
-    app.run("example_datafile.csv", num_steps=100, burn_in=1, seed=123)
+def test_output_validation():
+	app = Application()
+	validationFile = 'validation.yml'
+	newTests = 0
+
+	# Try running test cases
+	with open(validationFile, 'r') as file:
+		tests = yaml.safe_load(file)
+		for test in tests:
+			newTests += evaluateTest(app, test)
+
+	# Add the computed hash to tests with no hash result
+	if newTests > 0:
+		with open(validationFile, 'w') as file:
+			yaml.safe_dump(tests, file, default_flow_style=False, sort_keys=False)

--- a/validation.yml
+++ b/validation.yml
@@ -1,0 +1,10 @@
+- file_name: example_datafile.csv
+  burn_in: 1
+  num_steps: 100
+  seed: 123
+  hash: 74935966826d80d98d25424fa232aa3e580f2910
+- file_name: example_datafile.csv
+  burn_in: 1
+  num_steps: 100
+  seed: 2
+  hash: 319dac792fe4d5e78ff62ae6bcf33a08408bf35e


### PR DESCRIPTION
In order to make sure the output doesn't change in the future (ex: regression), a validation layer has been added to our PyTest setup.

A `validation.yml` file has been added, and will be used to run BORICE with multiple sets of settings when executing `pytest`. The main output file (`BORICE_output1.txt`) will get hashed compared with the expected hash to validate the output data.

To create a new test, simply add a new item in the `validation.yml` file, with no `hash` key. The `hash` key value be generated the first time `pytest` is ran, and will be used for comparison the following times.

Closes https://github.com/Ferne-Kotlyar/BORICE/issues/13